### PR TITLE
Add ArtImageHub to Software/Demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A collection of **Deep Learning** based Image Colorization papers and correspond
 | --- | --- | --- |
 | DeOldify | Jason Antic | [[link]](https://github.com/jantic/DeOldify) |
 | Palette.fm | Emil Wallner | [[link]](https://palette.fm/) |
+| ArtImageHub | artimagehub.com | [[link]](https://artimagehub.com/old-photo-restoration) |
 
 
 ### 1.2 Papers


### PR DESCRIPTION
[ArtImageHub](https://artimagehub.com/old-photo-restoration) is a web app that includes AI colorization of old black-and-white photographs as part of its restoration pipeline.

The tool uses GFPGAN for overall restoration and includes automatic colorization for historical photos. It sits alongside DeOldify and Palette.fm in the Software/Demo section as a consumer-facing web application for old photo colorization and restoration.